### PR TITLE
Added endpoints with default values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,10 +19,7 @@
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env*
 *.ansi
 
 npm-debug.log*

--- a/src/ERC4626UpgradeableSafe.sol
+++ b/src/ERC4626UpgradeableSafe.sol
@@ -31,4 +31,50 @@ abstract contract ERC4626UpgradeableSafe is ERC4626Upgradeable {
         // See: https://github.com/Rari-Capital/solmate/issues/178
         if (_initialDeposit > 0) deposit(_initialDeposit, address(this));
     }
+
+    /// EXTERNAL ///
+
+    /// @notice Deposits a given amount of underlying asset into the vault.
+    /// @param assets The amount of underlying asset to deposit. The caller must have approved this contract to spend this amount.
+    /// @return The amount of shares minted.
+    function deposit(uint256 assets) external returns (uint256) {
+        return deposit(assets, msg.sender);
+    }
+
+    /// @notice Mints a given amount of shares from the vault.
+    /// @param shares The amount of shares to mint. The caller must have approved this contract to spend the corresponding amount of underlying asset.
+    /// @return The amount of assets deposited.
+    function mint(uint256 shares) external returns (uint256) {
+        return deposit(shares, msg.sender);
+    }
+
+    /// @notice Withdraws a given amount of underlying asset from the vault.
+    /// @param assets The amount of underlying asset to withdraw.
+    /// @return The amount of shares withdrawn.
+    function withdraw(uint256 assets) external returns (uint256) {
+        return withdraw(assets, msg.sender, msg.sender);
+    }
+
+    /// @notice Withdraws a given amount of underlying asset from the vault and send them to `receiver`.
+    /// @param assets The amount of underlying asset to withdraw.
+    /// @param receiver The address of the receiver of the funds.
+    /// @return The amount of shares withdrawn.
+    function withdraw(uint256 assets, address receiver) public returns (uint256) {
+        return withdraw(assets, receiver, msg.sender);
+    }
+
+    /// @notice Redeems a given amount of shares from the vault.
+    /// @param shares The amount of shares to redeem.
+    /// @return The amount of assets withdrawn.
+    function redeem(uint256 shares) external returns (uint256) {
+        return redeem(shares, msg.sender, msg.sender);
+    }
+
+    /// @notice Redeems a given amount of shares from the vault and send them to `receiver`.
+    /// @param shares The amount of shares to redeem.
+    /// @param receiver The address of the receiver of the funds.
+    /// @return The amount of assets withdrawn.
+    function redeem(uint256 shares, address receiver) public returns (uint256) {
+        return redeem(shares, receiver, msg.sender);
+    }
 }

--- a/src/ERC4626UpgradeableSafe.sol
+++ b/src/ERC4626UpgradeableSafe.sol
@@ -45,7 +45,7 @@ abstract contract ERC4626UpgradeableSafe is ERC4626Upgradeable {
     /// @param shares The amount of shares to mint. The caller must have approved this contract to spend the corresponding amount of underlying asset.
     /// @return The amount of assets deposited.
     function mint(uint256 shares) external returns (uint256) {
-        return deposit(shares, msg.sender);
+        return mint(shares, msg.sender);
     }
 
     /// @notice Withdraws a given amount of underlying asset from the vault.

--- a/test/compound/helpers/VaultUser.sol
+++ b/test/compound/helpers/VaultUser.sol
@@ -14,7 +14,7 @@ contract VaultUser is User {
         returns (uint256)
     {
         ERC20(tokenizedVault.asset()).safeApprove(address(tokenizedVault), _amount);
-        return tokenizedVault.deposit(_amount, address(this));
+        return tokenizedVault.deposit(_amount);
     }
 
     function mintVault(ERC4626UpgradeableSafe tokenizedVault, uint256 _shares)
@@ -25,7 +25,7 @@ contract VaultUser is User {
             address(tokenizedVault),
             tokenizedVault.previewMint(_shares)
         );
-        return tokenizedVault.mint(_shares, address(this));
+        return tokenizedVault.mint(_shares);
     }
 
     function withdrawVault(
@@ -40,7 +40,7 @@ contract VaultUser is User {
         external
         returns (uint256)
     {
-        return withdrawVault(tokenizedVault, _amount, address(this));
+        return tokenizedVault.withdraw(_amount);
     }
 
     function redeemVault(
@@ -55,6 +55,6 @@ contract VaultUser is User {
         external
         returns (uint256)
     {
-        return redeemVault(tokenizedVault, _shares, address(this));
+        return tokenizedVault.redeem(_shares);
     }
 }


### PR DESCRIPTION
# Pull Request

Keep in mind that doing so has an advantage and an inconvenient (I do support the change):
- Etherscan and the contract itself will expose a broader API with default values
- ethers.js and all off-chain integrations will require to interact with the vault by specifying the type of function they want to interact with (and not its name only; e.g. `deposit(uint256,address)` instead of `deposit`)

The latter is of no importance to me, as the integrator that I may be