### PR TITLE
Added receiver argument to harvest

### DIFF
--- a/src/aave-v3/SupplyHarvestVault.sol
+++ b/src/aave-v3/SupplyHarvestVault.sol
@@ -23,12 +23,14 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
     /// EVENTS ///
 
     /// @notice Emitted when an harvest is done.
-    /// @param harvester The address of the harvester receiving the fee.
+    /// @param harvester The address triggering the harvest.
+    /// @param receiver The address receiving the harvest fee.
     /// @param rewardToken The address of the reward token swapped.
     /// @param rewardsAmount The amount of rewards in underlying asset which is supplied to Morpho.
     /// @param rewardsFee The amount of underlying asset sent to the harvester.
     event Harvested(
         address indexed harvester,
+        address indexed receiver,
         address indexed rewardToken,
         uint256 rewardsAmount,
         uint256 rewardsFee
@@ -161,7 +163,13 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
                 rewardsAmounts[i] = rewardsAmount;
                 totalSupplied += rewardsAmount;
 
-                emit Harvested(msg.sender, address(rewardToken), rewardsAmount, rewardFee);
+                emit Harvested(
+                    msg.sender,
+                    _receiver,
+                    address(rewardToken),
+                    rewardsAmount,
+                    rewardFee
+                );
             }
 
             unchecked {

--- a/src/aave-v3/SupplyHarvestVault.sol
+++ b/src/aave-v3/SupplyHarvestVault.sol
@@ -104,6 +104,7 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
     /// EXTERNAL ///
 
     /// @notice Harvests the vault: claims rewards from the underlying pool, swaps them for the underlying asset and supply them through Morpho.
+    /// @param _receiver The address of the receiver of the harvest fee.
     /// @return rewardTokens The addresses of reward tokens claimed.
     /// @return rewardsAmounts The amount of rewards claimed for each reward token (in underlying).
     /// @return totalSupplied The total amount of rewards swapped and supplied to Morpho (in underlying).

--- a/src/aave-v3/SupplyHarvestVault.sol
+++ b/src/aave-v3/SupplyHarvestVault.sol
@@ -108,7 +108,7 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
     /// @return rewardsAmounts The amount of rewards claimed for each reward token (in underlying).
     /// @return totalSupplied The total amount of rewards swapped and supplied to Morpho (in underlying).
     /// @return totalRewardsFee The total amount of fees swapped and taken by the claimer (in underlying).
-    function harvest()
+    function harvest(address _receiver)
         external
         returns (
             address[] memory rewardTokens,
@@ -168,7 +168,7 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
             }
         }
 
-        IERC20(assetMem).safeTransfer(msg.sender, totalRewardsFee);
+        IERC20(assetMem).safeTransfer(_receiver, totalRewardsFee);
         morpho.supply(poolTokenMem, address(this), totalSupplied);
     }
 }

--- a/src/aave-v3/interfaces/ISupplyHarvestVault.sol
+++ b/src/aave-v3/interfaces/ISupplyHarvestVault.sol
@@ -15,7 +15,7 @@ interface ISupplyHarvestVault is IERC4626Upgradeable {
 
     function setSwapper(address _swapper) external;
 
-    function harvest()
+    function harvest(address _receiver)
         external
         returns (
             address[] memory rewardTokens,

--- a/src/compound/SupplyHarvestVault.sol
+++ b/src/compound/SupplyHarvestVault.sol
@@ -20,10 +20,16 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
     /// EVENTS ///
 
     /// @notice Emitted when an harvest is done.
-    /// @param harvester The address of the harvester receiving the fee.
+    /// @param harvester The address triggering the harvest.
+    /// @param receiver The address receiving the harvest fee.
     /// @param rewardsAmount The amount of rewards in underlying asset which is supplied to Morpho.
     /// @param rewardsFee The amount of underlying asset sent to the harvester.
-    event Harvested(address indexed harvester, uint256 rewardsAmount, uint256 rewardsFee);
+    event Harvested(
+        address indexed harvester,
+        address indexed receiver,
+        uint256 rewardsAmount,
+        uint256 rewardsFee
+    );
 
     /// @notice Emitted when the fee for swapping comp for WETH is set.
     /// @param newCompSwapFee The new comp swap fee (in UniswapV3 fee unit).
@@ -187,7 +193,7 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
         morpho.supply(poolTokenMem, address(this), rewardsAmount);
         if (rewardsFee > 0) IERC20(assetMem).safeTransfer(_receiver, rewardsFee);
 
-        emit Harvested(msg.sender, rewardsAmount, rewardsFee);
+        emit Harvested(msg.sender, _receiver, rewardsAmount, rewardsFee);
     }
 
     /// GETTERS ///

--- a/src/compound/SupplyHarvestVault.sol
+++ b/src/compound/SupplyHarvestVault.sol
@@ -140,6 +140,7 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
     /// EXTERNAL ///
 
     /// @notice Harvests the vault: claims rewards from the underlying pool, swaps them for the underlying asset and supply them through Morpho.
+    /// @param _receiver The address of the receiver of the harvest fee.
     /// @return rewardsAmount The amount of rewards claimed, swapped then supplied through Morpho (in underlying).
     /// @return rewardsFee The amount of fees taken by the claimer (in underlying).
     function harvest(address _receiver)

--- a/src/compound/SupplyHarvestVault.sol
+++ b/src/compound/SupplyHarvestVault.sol
@@ -142,7 +142,10 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
     /// @notice Harvests the vault: claims rewards from the underlying pool, swaps them for the underlying asset and supply them through Morpho.
     /// @return rewardsAmount The amount of rewards claimed, swapped then supplied through Morpho (in underlying).
     /// @return rewardsFee The amount of fees taken by the claimer (in underlying).
-    function harvest() external returns (uint256 rewardsAmount, uint256 rewardsFee) {
+    function harvest(address _receiver)
+        external
+        returns (uint256 rewardsAmount, uint256 rewardsFee)
+    {
         address assetMem = asset();
         address poolTokenMem = poolToken;
         address compMem = address(comp);
@@ -181,7 +184,7 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
         }
 
         morpho.supply(poolTokenMem, address(this), rewardsAmount);
-        if (rewardsFee > 0) IERC20(assetMem).safeTransfer(msg.sender, rewardsFee);
+        if (rewardsFee > 0) IERC20(assetMem).safeTransfer(_receiver, rewardsFee);
 
         emit Harvested(msg.sender, rewardsAmount, rewardsFee);
     }

--- a/src/compound/interfaces/ISupplyHarvestVault.sol
+++ b/src/compound/interfaces/ISupplyHarvestVault.sol
@@ -37,5 +37,7 @@ interface ISupplyHarvestVault is IERC4626Upgradeable {
 
     function setHarvestingFee(uint16 _newHarvestingFee) external;
 
-    function harvest() external returns (uint256 rewardsAmount, uint256 rewardsFee);
+    function harvest(address _receiver)
+        external
+        returns (uint256 rewardsAmount, uint256 rewardsFee);
 }

--- a/test/aave-v3/TestSupplyHarvestVault.t.sol
+++ b/test/aave-v3/TestSupplyHarvestVault.t.sol
@@ -215,7 +215,7 @@ contract TestSupplyHarvestVault is TestSetupVaults {
             uint256[] memory rewardsAmounts,
             uint256 totalSupplied,
             uint256 totalRewardsFee
-        ) = daiSupplyHarvestVault.harvest();
+        ) = daiSupplyHarvestVault.harvest(address(this));
 
         assertEq(rewardTokens.length, 1);
         assertEq(rewardTokens[0], rewardToken);
@@ -265,7 +265,7 @@ contract TestSupplyHarvestVault is TestSetupVaults {
             uint256[] memory rewardsAmounts,
             uint256 totalSupplied,
             uint256 totalRewardsFee
-        ) = daiSupplyHarvestVault.harvest();
+        ) = daiSupplyHarvestVault.harvest(address(1));
 
         assertEq(rewardTokens.length, 1);
         assertEq(rewardTokens[0], rewardToken);
@@ -291,7 +291,7 @@ contract TestSupplyHarvestVault is TestSetupVaults {
             "unexpected dai balance"
         );
         assertApproxEqAbs(totalRewardsFee, expectedRewardsFee, 1, "unexpected rewards fee amount");
-        assertEq(ERC20(dai).balanceOf(address(this)), totalRewardsFee, "unexpected fee collected");
+        assertEq(ERC20(dai).balanceOf(address(1)), totalRewardsFee, "unexpected fee collected");
     }
 
     /// GOVERNANCE ///

--- a/test/aave-v3/TestWrappedNativeToken.t.sol
+++ b/test/aave-v3/TestWrappedNativeToken.t.sol
@@ -68,7 +68,7 @@ contract TestWrappedNativeToken is TestSetupVaults {
             uint256[] memory rewardsAmounts,
             uint256 totalSupplied,
             uint256 totalRewardsFee
-        ) = wrappedNativeTokenSupplyHarvestVault.harvest();
+        ) = wrappedNativeTokenSupplyHarvestVault.harvest(address(this));
 
         assertEq(rewardTokens.length, 1, "unexpected reward tokens length");
         assertEq(rewardTokens[0], rewardToken, "unexpected reward token");

--- a/test/aave-v3/setup/TestSetupVaults.sol
+++ b/test/aave-v3/setup/TestSetupVaults.sol
@@ -172,10 +172,6 @@ contract TestSetupVaults is TestSetup {
             );
         }
 
-        supplier1 = suppliers[0];
-        supplier2 = suppliers[1];
-        supplier3 = suppliers[2];
-
         vaultSupplier1 = VaultUser(payable(suppliers[0]));
         vaultSupplier2 = VaultUser(payable(suppliers[1]));
         vaultSupplier3 = VaultUser(payable(suppliers[2]));

--- a/test/compound/TestComp.t.sol
+++ b/test/compound/TestComp.t.sol
@@ -60,7 +60,7 @@ contract TestComp is TestSetupVaults {
             address(compSupplyHarvestVault)
         );
 
-        (uint256 rewardsAmount, uint256 rewardsFee) = compSupplyHarvestVault.harvest();
+        (uint256 rewardsAmount, uint256 rewardsFee) = compSupplyHarvestVault.harvest(address(2));
 
         (, uint256 balanceOnPoolAfter) = morpho.supplyBalanceInOf(
             cComp,
@@ -84,6 +84,6 @@ contract TestComp is TestSetupVaults {
             "unexpected balance on pool"
         );
         assertApproxEqAbs(rewardsFee, expectedRewardsFee, 1, "unexpected rewards fee");
-        assertEq(ERC20(comp).balanceOf(address(this)), rewardsFee, "unexpected fee collected");
+        assertEq(ERC20(comp).balanceOf(address(2)), rewardsFee, "unexpected fee collected");
     }
 }

--- a/test/compound/TestEth.t.sol
+++ b/test/compound/TestEth.t.sol
@@ -61,7 +61,7 @@ contract TestEth is TestSetupVaults {
             address(wethSupplyHarvestVault)
         );
 
-        (uint256 rewardsAmount, uint256 rewardsFee) = wethSupplyHarvestVault.harvest();
+        (uint256 rewardsAmount, uint256 rewardsFee) = wethSupplyHarvestVault.harvest(address(3));
         uint256 expectedRewardsFee = (rewardsAmount + rewardsFee).percentMul(
             wethSupplyHarvestVault.harvestingFee()
         );
@@ -83,6 +83,6 @@ contract TestEth is TestSetupVaults {
             "comp amount is not zero"
         );
         assertEq(rewardsFee, expectedRewardsFee, "unexpected rewards fee amount");
-        assertEq(ERC20(wEth).balanceOf(address(this)), rewardsFee, "unexpected fee collected");
+        assertEq(ERC20(wEth).balanceOf(address(3)), rewardsFee, "unexpected fee collected");
     }
 }

--- a/test/compound/TestSupplyHarvestVault.t.sol
+++ b/test/compound/TestSupplyHarvestVault.t.sol
@@ -243,7 +243,7 @@ contract TestSupplyHarvestVault is TestSetupVaults {
             address(daiSupplyHarvestVault)
         );
 
-        (uint256 rewardsAmount, uint256 rewardsFee) = daiSupplyHarvestVault.harvest();
+        (uint256 rewardsAmount, uint256 rewardsFee) = daiSupplyHarvestVault.harvest(address(this));
 
         uint256 harvestingFee = daiSupplyHarvestVault.harvestingFee();
         uint256 expectedRewardsFee = (rewardsAmount * harvestingFee) /
@@ -283,7 +283,7 @@ contract TestSupplyHarvestVault is TestSetupVaults {
         );
         uint256 balanceBefore = vaultSupplier1.balanceOf(dai);
 
-        (uint256 rewardsAmount, uint256 rewardsFee) = daiSupplyHarvestVault.harvest();
+        (uint256 rewardsAmount, uint256 rewardsFee) = daiSupplyHarvestVault.harvest(address(4));
 
         uint256 harvestingFee = daiSupplyHarvestVault.harvestingFee();
         uint256 expectedRewardsFee = (rewardsAmount * harvestingFee) /
@@ -303,7 +303,7 @@ contract TestSupplyHarvestVault is TestSetupVaults {
             "unexpected dai balance"
         );
         assertApproxEqAbs(rewardsFee, expectedRewardsFee, 1, "unexpected rewards fee amount");
-        assertEq(ERC20(dai).balanceOf(address(this)), rewardsFee, "unexpected fee collected");
+        assertEq(ERC20(dai).balanceOf(address(4)), rewardsFee, "unexpected fee collected");
     }
 
     /// GOVERNANCE ///

--- a/test/compound/live/TestCompLive.t.sol
+++ b/test/compound/live/TestCompLive.t.sol
@@ -76,7 +76,7 @@ contract TestCompLive is TestSetupVaultsLive {
             address(compSupplyHarvestVault)
         );
 
-        (uint256 rewardsAmount, uint256 rewardsFee) = compSupplyHarvestVault.harvest();
+        (uint256 rewardsAmount, uint256 rewardsFee) = compSupplyHarvestVault.harvest(address(2));
 
         (, uint256 balanceOnPoolAfter) = morpho.supplyBalanceInOf(
             cComp,
@@ -100,6 +100,6 @@ contract TestCompLive is TestSetupVaultsLive {
             "unexpected balance on pool"
         );
         assertApproxEqAbs(rewardsFee, expectedRewardsFee, 1, "unexpected rewards fee");
-        assertEq(ERC20(comp).balanceOf(address(this)), rewardsFee, "unexpected fee collected");
+        assertEq(ERC20(comp).balanceOf(address(2)), rewardsFee, "unexpected fee collected");
     }
 }

--- a/test/compound/live/TestEthLive.t.sol
+++ b/test/compound/live/TestEthLive.t.sol
@@ -76,7 +76,7 @@ contract TestEthLive is TestSetupVaultsLive {
         );
         uint256 poolSupplyIndex = ICToken(cEth).exchangeRateCurrent();
         uint256 p2pSupplyIndex = morpho.p2pSupplyIndex(cEth);
-        (uint256 rewardsAmount, uint256 rewardsFee) = wethSupplyHarvestVault.harvest();
+        (uint256 rewardsAmount, uint256 rewardsFee) = wethSupplyHarvestVault.harvest(address(3));
         uint256 expectedRewardsFee = (rewardsAmount + rewardsFee).percentMul(
             wethSupplyHarvestVault.harvestingFee()
         );
@@ -101,6 +101,6 @@ contract TestEthLive is TestSetupVaultsLive {
             "comp amount is not zero"
         );
         assertEq(rewardsFee, expectedRewardsFee, "unexpected rewards fee amount");
-        assertEq(ERC20(wEth).balanceOf(address(this)), rewardsFee, "unexpected fee collected");
+        assertEq(ERC20(wEth).balanceOf(address(3)), rewardsFee, "unexpected fee collected");
     }
 }

--- a/test/compound/live/TestSupplyHarvestVaultLive.t.sol
+++ b/test/compound/live/TestSupplyHarvestVaultLive.t.sol
@@ -200,7 +200,7 @@ contract TestSupplyHarvestVaultLive is TestSetupVaultsLive {
             address(daiSupplyHarvestVault)
         );
 
-        (uint256 rewardsAmount, uint256 rewardsFee) = daiSupplyHarvestVault.harvest();
+        (uint256 rewardsAmount, uint256 rewardsFee) = daiSupplyHarvestVault.harvest(address(this));
 
         uint256 harvestingFee = daiSupplyHarvestVault.harvestingFee();
         uint256 expectedRewardsFee = (rewardsAmount * harvestingFee) /
@@ -240,7 +240,7 @@ contract TestSupplyHarvestVaultLive is TestSetupVaultsLive {
         );
         uint256 balanceBefore = vaultSupplier1.balanceOf(dai);
 
-        (uint256 rewardsAmount, uint256 rewardsFee) = daiSupplyHarvestVault.harvest();
+        (uint256 rewardsAmount, uint256 rewardsFee) = daiSupplyHarvestVault.harvest(address(4));
 
         uint256 harvestingFee = daiSupplyHarvestVault.harvestingFee();
         uint256 expectedRewardsFee = (rewardsAmount * harvestingFee) /
@@ -260,7 +260,7 @@ contract TestSupplyHarvestVaultLive is TestSetupVaultsLive {
             "unexpected dai balance"
         );
         assertApproxEqAbs(rewardsFee, expectedRewardsFee, 1, "unexpected rewards fee amount");
-        assertEq(ERC20(dai).balanceOf(address(this)), rewardsFee, "unexpected fee collected");
+        assertEq(ERC20(dai).balanceOf(address(4)), rewardsFee, "unexpected fee collected");
     }
 
     /// GOVERNANCE ///


### PR DESCRIPTION
# Pull Request

## Issue(s) fixed

This pull request adds the ability to send harvested funds to a given address

Tests are failing and it's expected as the currently deployed version of harvest vault don't expect a `receiver` argument