### PR TITLE
🔧 Set optimizer runs to higher value

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,7 +1,7 @@
 [profile.default]
 auto_detect_solc = true
 optimizer = true
-optimizer_runs = 200
+optimizer_runs = 100000
 via_ir = false
 # If enabled, the Solidity compiler is instructed to generate bytecode
 # only for the required contracts. This can reduce compile time


### PR DESCRIPTION
Allows to optimize gas cost when calling deployed contracts