### PR TITLE
Correct accruing of rewards in edge case

### DIFF
--- a/src/compound/SupplyVault.sol
+++ b/src/compound/SupplyVault.sol
@@ -99,7 +99,7 @@ contract SupplyVault is ISupplyVault, SupplyVaultBase {
         uint256 _assets,
         uint256 _shares
     ) internal virtual override {
-        _accrueUnclaimedRewards(_receiver);
+        _accrueUnclaimedRewards(_owner);
         super._withdraw(_caller, _receiver, _owner, _assets, _shares);
     }
 

--- a/test/aave-v2/helpers/VaultUser.sol
+++ b/test/aave-v2/helpers/VaultUser.sol
@@ -46,6 +46,15 @@ contract VaultUser is User {
     function redeemVault(
         ERC4626UpgradeableSafe tokenizedVault,
         uint256 _shares,
+        address _receiver,
+        address _owner
+    ) public returns (uint256) {
+        return tokenizedVault.redeem(_shares, _receiver, _owner);
+    }
+
+    function redeemVault(
+        ERC4626UpgradeableSafe tokenizedVault,
+        uint256 _shares,
         address _owner
     ) public returns (uint256) {
         return tokenizedVault.redeem(_shares, address(this), _owner);

--- a/test/aave-v3/helpers/VaultUser.sol
+++ b/test/aave-v3/helpers/VaultUser.sol
@@ -46,6 +46,15 @@ contract VaultUser is User {
     function redeemVault(
         ERC4626UpgradeableSafe tokenizedVault,
         uint256 _shares,
+        address _receiver,
+        address _owner
+    ) public returns (uint256) {
+        return tokenizedVault.redeem(_shares, _receiver, _owner);
+    }
+
+    function redeemVault(
+        ERC4626UpgradeableSafe tokenizedVault,
+        uint256 _shares,
         address _owner
     ) public returns (uint256) {
         return tokenizedVault.redeem(_shares, address(this), _owner);

--- a/test/compound/TestSupplyVault.t.sol
+++ b/test/compound/TestSupplyVault.t.sol
@@ -358,18 +358,17 @@ contract TestSupplyVault is TestSetupVaults {
     function testAccrueRewardsToCorrectUser() public {
         uint256 amount = 1e6 ether;
 
-        vm.startPrank(address(supplier1));
         ERC20(dai).approve(address(daiSupplyVault), type(uint256).max);
-        daiSupplyVault.deposit(amount, address(supplier1));
+        vaultSupplier1.depositVault(daiSupplyVault, amount);
 
         vm.roll(block.number + 1000);
 
-        daiSupplyVault.redeem(
+        vaultSupplier1.redeemVault(
+            daiSupplyVault,
             daiSupplyVault.balanceOf(address(supplier1)),
             address(supplier2),
             address(supplier1)
         );
-        vm.stopPrank();
 
         // Balance of supplier1 is expected to be 0.
         assertEq(daiSupplyVault.balanceOf(address(supplier1)), 0);

--- a/test/compound/helpers/VaultUser.sol
+++ b/test/compound/helpers/VaultUser.sol
@@ -46,6 +46,15 @@ contract VaultUser is User {
     function redeemVault(
         ERC4626UpgradeableSafe tokenizedVault,
         uint256 _shares,
+        address _receiver,
+        address _owner
+    ) public returns (uint256) {
+        return tokenizedVault.redeem(_shares, _receiver, _owner);
+    }
+
+    function redeemVault(
+        ERC4626UpgradeableSafe tokenizedVault,
+        uint256 _shares,
         address _owner
     ) public returns (uint256) {
         return tokenizedVault.redeem(_shares, address(this), _owner);


### PR DESCRIPTION
Fix an issue when `owner != receiver`
Fix #169 