### PR TITLE
Refactor transfer scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,7 @@ FOUNDRY_ETH_RPC_URL?=https://${NETWORK}.g.alchemy.com/v2/${ALCHEMY_KEY}
 
 ifeq (${NETWORK}, eth-mainnet)
   FOUNDRY_CHAIN_ID=1
-  FOUNDRY_FORK_BLOCK_NUMBER=14292587
-  ifeq (${PROTOCOL}, aave-v2)
-    FOUNDRY_FORK_BLOCK_NUMBER=15485110
-  endif
+  FOUNDRY_FORK_BLOCK_NUMBER=15485110
 endif
 
 ifeq (${NETWORK}, polygon-mainnet)

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ FOUNDRY_ETH_RPC_URL?=https://${NETWORK}.g.alchemy.com/v2/${ALCHEMY_KEY}
 
 ifeq (${NETWORK}, eth-mainnet)
   FOUNDRY_CHAIN_ID=1
-  FOUNDRY_FORK_BLOCK_NUMBER=15485110
+  FOUNDRY_FORK_BLOCK_NUMBER=15425110
 endif
 
 ifeq (${NETWORK}, polygon-mainnet)

--- a/src/aave-v2/SupplyVault.sol
+++ b/src/aave-v2/SupplyVault.sol
@@ -14,7 +14,8 @@ contract SupplyVault is ISupplyVault, SupplyVaultBase {
 
     /// @dev Initializes network-wide immutables.
     /// @param _morpho The address of the main Morpho contract.
-    constructor(address _morpho) SupplyVaultBase(_morpho) {}
+    /// @param _morphoToken The address of the Morpho Token.
+    constructor(address _morpho, address _morphoToken) SupplyVaultBase(_morpho, _morphoToken) {}
 
     /// INITIALIZER ///
 

--- a/src/aave-v2/SupplyVaultBase.sol
+++ b/src/aave-v2/SupplyVaultBase.sol
@@ -22,7 +22,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// EVENTS ///
 
-    /// @notice Emitted when a new rewards `recipient` is set.
+    /// @notice Emitted when MORPHO rewards are transferred to `recipient`.
     /// @param recipient The recipient of the rewards.
     event RewardsRecipientSet(address recipient);
 
@@ -33,7 +33,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// ERRORS ///
 
-    /// @notice Thrown when the zero address is passed as input.
+    /// @notice Thrown when the zero address is passed as input or is the recipient address when calling `transferRewards`.
     error ZeroAddress();
 
     /// CONSTANTS AND IMMUTABLES ///

--- a/src/aave-v2/SupplyVaultBase.sol
+++ b/src/aave-v2/SupplyVaultBase.sol
@@ -102,8 +102,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     }
 
     /// @notice Transfers the MORPHO rewards to the rewards recipient.
-    /// @dev Anybody can trigger this function. This offloads the DAO to do it.
-    function transferRewards() external {
+    function transferRewards() external onlyOwner {
         if (recipient == address(0)) revert ZeroAddress();
         uint256 amount = morphoToken.balanceOf(address(this));
         morphoToken.safeTransfer(recipient, amount);

--- a/src/aave-v2/SupplyVaultBase.sol
+++ b/src/aave-v2/SupplyVaultBase.sol
@@ -22,11 +22,11 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// EVENTS ///
 
-    /// @notice Emitted when MORPHO rewards are transferred to `recipient`.
+    /// @notice Emitted when the `recipient` of MORPHO rewards is set.
     /// @param recipient The recipient of the rewards.
     event RewardsRecipientSet(address recipient);
 
-    /// @notice Emitted when rewards rewards are transferred to `recipient`.
+    /// @notice Emitted when MORPHO rewards are transferred to `recipient`.
     /// @param recipient The recipient of the rewards.
     /// @param amount The amount of rewards transferred.
     event RewardsTransferred(address recipient, uint256 amount);
@@ -94,6 +94,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     /// EXTERNAL ///
 
     /// @notice Sets the rewards recipient.
+    /// @dev Sets to address(0) to prevent MORPHO rewards from being transferred.
     /// @param _recipient The new rewards recipient.
     function setRewardsRecipient(address _recipient) external onlyOwner {
         recipient = _recipient;

--- a/src/aave-v2/SupplyVaultBase.sol
+++ b/src/aave-v2/SupplyVaultBase.sol
@@ -96,7 +96,6 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     /// @notice Sets the rewards recipient.
     /// @param _recipient The new rewards recipient.
     function setRewardsRecipient(address _recipient) external onlyOwner {
-        if (_recipient == address(0)) revert ZeroAddress();
         recipient = _recipient;
         emit RewardsRecipientSet(_recipient);
     }

--- a/src/aave-v3/SupplyHarvestVault.sol
+++ b/src/aave-v3/SupplyHarvestVault.sol
@@ -61,7 +61,8 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
 
     /// @dev Initializes network-wide immutables.
     /// @param _morpho The address of the main Morpho contract.
-    constructor(address _morpho) SupplyVaultBase(_morpho) {}
+    /// @param _morphoToken The address of the Morpho Token.
+    constructor(address _morpho, address _morphoToken) SupplyVaultBase(_morpho, _morphoToken) {}
 
     /// INITIALIZER ///
 

--- a/src/aave-v3/SupplyVault.sol
+++ b/src/aave-v3/SupplyVault.sol
@@ -60,7 +60,8 @@ contract SupplyVault is ISupplyVault, SupplyVaultBase {
 
     /// @dev Initializes network-wide immutables.
     /// @param _morpho The address of the main Morpho contract.
-    constructor(address _morpho) SupplyVaultBase(_morpho) {
+    /// @param _morphoToken The address of the Morpho Token.
+    constructor(address _morpho, address _morphoToken) SupplyVaultBase(_morpho, _morphoToken) {
         rewardsManager = morpho.rewardsManager();
     }
 

--- a/src/aave-v3/SupplyVaultBase.sol
+++ b/src/aave-v3/SupplyVaultBase.sol
@@ -23,7 +23,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// EVENTS ///
 
-    /// @notice Emitted when a new rewards `recipient` is set.
+    /// @notice Emitted when MORPHO rewards are transferred to `recipient`.
     /// @param recipient The recipient of the rewards.
     event RewardsRecipientSet(address recipient);
 
@@ -34,7 +34,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// ERRORS ///
 
-    /// @notice Thrown when the zero address is passed as input.
+    /// @notice Thrown when the zero address is passed as input or is the recipient address when calling `transferRewards`.
     error ZeroAddress();
 
     /// CONSTANTS AND IMMUTABLES ///

--- a/src/aave-v3/SupplyVaultBase.sol
+++ b/src/aave-v3/SupplyVaultBase.sol
@@ -40,14 +40,16 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     /// CONSTANTS AND IMMUTABLES ///
 
     IMorpho public immutable morpho; // The main Morpho contract.
-    ERC20 public immutable morphoToken;
+    ERC20 public immutable morphoToken; // The address of the Morpho Token.
+
+    /// STORAGE ///
 
     address public poolToken; // The pool token corresponding to the market to supply to through this vault.
     address public recipient; // The recipient of the rewards that will redistribute them to vault's users.
 
     /// CONSTRUCTOR ///
 
-    /// @dev Initializes network-wide immutables
+    /// @dev Initializes network-wide immutables.
     /// @param _morpho The address of the main Morpho contract.
     /// @param _morphoToken The address of the Morpho Token.
     constructor(address _morpho, address _morphoToken) {
@@ -86,7 +88,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     {
         poolToken = _poolToken;
 
-        underlyingToken = ERC20(IAToken(poolToken).UNDERLYING_ASSET_ADDRESS()); // Reverts on zero address so no check for pool token needed
+        underlyingToken = ERC20(IAToken(poolToken).UNDERLYING_ASSET_ADDRESS()); // Reverts on zero address so no check for pool token needed.
         underlyingToken.safeApprove(address(morpho), type(uint256).max);
     }
 

--- a/src/aave-v3/SupplyVaultBase.sol
+++ b/src/aave-v3/SupplyVaultBase.sol
@@ -103,8 +103,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     }
 
     /// @notice Transfers the MORPHO rewards to the rewards recipient.
-    /// @dev Anybody can trigger this function. This offloads the DAO to do it.
-    function transferRewards() external {
+    function transferRewards() external onlyOwner {
         if (recipient == address(0)) revert ZeroAddress();
         uint256 amount = morphoToken.balanceOf(address(this));
         morphoToken.safeTransfer(recipient, amount);

--- a/src/aave-v3/SupplyVaultBase.sol
+++ b/src/aave-v3/SupplyVaultBase.sol
@@ -97,7 +97,6 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     /// @notice Sets the rewards recipient.
     /// @param _recipient The new rewards recipient.
     function setRewardsRecipient(address _recipient) external onlyOwner {
-        if (_recipient == address(0)) revert ZeroAddress();
         recipient = _recipient;
         emit RewardsRecipientSet(_recipient);
     }

--- a/src/aave-v3/SupplyVaultBase.sol
+++ b/src/aave-v3/SupplyVaultBase.sol
@@ -23,11 +23,11 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// EVENTS ///
 
-    /// @notice Emitted when MORPHO rewards are transferred to `recipient`.
+    /// @notice Emitted when the `recipient` of MORPHO rewards is set.
     /// @param recipient The recipient of the rewards.
     event RewardsRecipientSet(address recipient);
 
-    /// @notice Emitted when rewards rewards are transferred to `recipient`.
+    /// @notice Emitted when MORPHO rewards are transferred to `recipient`.
     /// @param recipient The recipient of the rewards.
     /// @param amount The amount of rewards transferred.
     event RewardsTransferred(address recipient, uint256 amount);
@@ -95,6 +95,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     /// EXTERNAL ///
 
     /// @notice Sets the rewards recipient.
+    /// @dev Sets to address(0) to prevent MORPHO rewards from being transferred.
     /// @param _recipient The new rewards recipient.
     function setRewardsRecipient(address _recipient) external onlyOwner {
         recipient = _recipient;

--- a/src/compound/SupplyHarvestVault.sol
+++ b/src/compound/SupplyHarvestVault.sol
@@ -79,7 +79,8 @@ contract SupplyHarvestVault is ISupplyHarvestVault, SupplyVaultBase {
 
     /// @dev Initializes network-wide immutables.
     /// @param _morpho The address of the main Morpho contract.
-    constructor(address _morpho) SupplyVaultBase(_morpho) {}
+    /// @param _morphoToken The address of the Morpho Token.
+    constructor(address _morpho, address _morphoToken) SupplyVaultBase(_morpho, _morphoToken) {}
 
     /// INITIALIZER ///
 

--- a/src/compound/SupplyVault.sol
+++ b/src/compound/SupplyVault.sol
@@ -45,7 +45,8 @@ contract SupplyVault is ISupplyVault, SupplyVaultBase {
 
     /// @dev Initializes network-wide immutables.
     /// @param _morpho The address of the main Morpho contract.
-    constructor(address _morpho) SupplyVaultBase(_morpho) {}
+    /// @param _morphoToken The address of the Morpho Token.
+    constructor(address _morpho, address _morphoToken) SupplyVaultBase(_morpho, _morphoToken) {}
 
     /// INITIALIZER ///
 

--- a/src/compound/SupplyVaultBase.sol
+++ b/src/compound/SupplyVaultBase.sol
@@ -110,8 +110,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     }
 
     /// @notice Transfers the MORPHO rewards to the rewards recipient.
-    /// @dev Anybody can trigger this function. This offloads the DAO to do it.
-    function transferRewards() external {
+    function transferRewards() external onlyOwner {
         if (recipient == address(0)) revert ZeroAddress();
         uint256 amount = morphoToken.balanceOf(address(this));
         morphoToken.safeTransfer(recipient, amount);

--- a/src/compound/SupplyVaultBase.sol
+++ b/src/compound/SupplyVaultBase.sol
@@ -21,11 +21,11 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// EVENTS ///
 
-    /// @notice Emitted when MORPHO rewards are transferred to `recipient`.
+    /// @notice Emitted when the `recipient` of MORPHO rewards is set.
     /// @param recipient The recipient of the rewards.
     event RewardsRecipientSet(address recipient);
 
-    /// @notice Emitted when rewards rewards are transferred to `recipient`.
+    /// @notice Emitted when MORPHO rewards are transferred to `recipient`.
     /// @param recipient The recipient of the rewards.
     /// @param amount The amount of rewards transferred.
     event RewardsTransferred(address recipient, uint256 amount);
@@ -102,6 +102,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     /// EXTERNAL ///
 
     /// @notice Sets the rewards recipient.
+    /// @dev Sets to address(0) to prevent MORPHO rewards from being transferred.
     /// @param _recipient The new rewards recipient.
     function setRewardsRecipient(address _recipient) external onlyOwner {
         recipient = _recipient;

--- a/src/compound/SupplyVaultBase.sol
+++ b/src/compound/SupplyVaultBase.sol
@@ -104,7 +104,6 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     /// @notice Sets the rewards recipient.
     /// @param _recipient The new rewards recipient.
     function setRewardsRecipient(address _recipient) external onlyOwner {
-        if (_recipient == address(0)) revert ZeroAddress();
         recipient = _recipient;
         emit RewardsRecipientSet(_recipient);
     }

--- a/src/compound/SupplyVaultBase.sol
+++ b/src/compound/SupplyVaultBase.sol
@@ -37,11 +37,10 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// CONSTANTS AND IMMUTABLES ///
 
-    ERC20 public constant MORPHO = ERC20(0x9994E35Db50125E0DF82e4c2dde62496CE330999);
-
     IMorpho public immutable morpho; // The main Morpho contract.
     address public immutable wEth; // The address of WETH token.
     ERC20 public immutable comp; // The COMP token.
+    ERC20 public immutable morphoToken; // The address of the Morpho Token.
 
     /// STORAGE ///
 
@@ -52,10 +51,13 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// @dev Initializes network-wide immutables.
     /// @param _morpho The address of the main Morpho contract.
-    constructor(address _morpho) {
+    /// @param _morphoToken The address of the Morpho Token.
+    constructor(address _morpho, address _morphoToken) {
+        if (_morphoToken == address(0)) revert ZeroAddress();
         morpho = IMorpho(_morpho);
         wEth = morpho.wEth();
         comp = ERC20(morpho.comptroller().getCompAddress());
+        morphoToken = ERC20(_morphoToken);
     }
 
     /// INITIALIZER ///
@@ -111,8 +113,8 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
     /// @dev Anybody can trigger this function. This offloads the DAO to do it.
     function transferRewards() external {
         if (recipient == address(0)) revert ZeroAddress();
-        uint256 amount = MORPHO.balanceOf(address(this));
-        MORPHO.safeTransfer(recipient, amount);
+        uint256 amount = morphoToken.balanceOf(address(this));
+        morphoToken.safeTransfer(recipient, amount);
         emit RewardsTransferred(recipient, amount);
     }
 

--- a/src/compound/SupplyVaultBase.sol
+++ b/src/compound/SupplyVaultBase.sol
@@ -21,7 +21,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// EVENTS ///
 
-    /// @notice Emitted when a new rewards `recipient` is set.
+    /// @notice Emitted when MORPHO rewards are transferred to `recipient`.
     /// @param recipient The recipient of the rewards.
     event RewardsRecipientSet(address recipient);
 
@@ -32,7 +32,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// ERRORS ///
 
-    /// @notice Thrown when the zero address is passed as input.
+    /// @notice Thrown when the zero address is passed as input or is the recipient address when calling `transferRewards`.
     error ZeroAddress();
 
     /// CONSTANTS AND IMMUTABLES ///

--- a/src/compound/SupplyVaultBase.sol
+++ b/src/compound/SupplyVaultBase.sol
@@ -99,12 +99,16 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// EXTERNAL ///
 
+    /// @notice Sets the rewards recipient.
+    /// @param _recipient The new rewards recipient.
     function setRewardsRecipient(address _recipient) external onlyOwner {
         if (_recipient == address(0)) revert ZeroAddress();
         recipient = _recipient;
         emit RewardsRecipientSet(_recipient);
     }
 
+    /// @notice Transfers the MORPHO rewards to the rewards recipient.
+    /// @dev Anybody can trigger this function. This offloads the DAO to do it.
     function transferRewards() external {
         if (recipient == address(0)) revert ZeroAddress();
         uint256 amount = MORPHO.balanceOf(address(this));

--- a/src/compound/SupplyVaultBase.sol
+++ b/src/compound/SupplyVaultBase.sol
@@ -23,7 +23,7 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// @notice Emitted when a new rewards `recipient` is set.
     /// @param recipient The recipient of the rewards.
-    event RecipientSet(address recipient);
+    event RewardsRecipientSet(address recipient);
 
     /// @notice Emitted when rewards rewards are transferred to `recipient`.
     /// @param recipient The recipient of the rewards.
@@ -99,10 +99,10 @@ abstract contract SupplyVaultBase is ERC4626UpgradeableSafe, OwnableUpgradeable 
 
     /// EXTERNAL ///
 
-    function setRecipient(address _recipient) external onlyOwner() {
+    function setRewardsRecipient(address _recipient) external onlyOwner {
         if (_recipient == address(0)) revert ZeroAddress();
         recipient = _recipient;
-        emit RecipientSet(_recipient);
+        emit RewardsRecipientSet(_recipient);
     }
 
     function transferRewards() external {

--- a/test/aave-v2/TestSupplyVault.t.sol
+++ b/test/aave-v2/TestSupplyVault.t.sol
@@ -167,26 +167,4 @@ contract TestSupplyVault is TestSetupVaults {
         vm.expectRevert("ERC4626: redeem more than max");
         vaultSupplier1.redeemVault(daiSupplyVault, shares + 1);
     }
-
-    function testNotOwnerShouldNotTransferTokens(uint256 _amount) public {
-        vm.prank(address(1));
-        vm.expectRevert("Ownable: caller is not the owner");
-        daiSupplyVault.transferTokens($token, address(2), _amount);
-    }
-
-    function testOwnerShouldTransferTokens(
-        address _to,
-        uint256 _deal,
-        uint256 _toTransfer
-    ) public {
-        vm.assume(_to != address(daiSupplyVault));
-        _toTransfer = bound(_toTransfer, 0, _deal);
-        deal($token, address(daiSupplyVault), _deal);
-
-        vm.prank(daiSupplyVault.owner());
-        daiSupplyVault.transferTokens($token, _to, _toTransfer);
-
-        assertEq(token.balanceOf(address(daiSupplyVault)), _deal - _toTransfer);
-        assertEq(token.balanceOf(_to), _toTransfer);
-    }
 }

--- a/test/aave-v2/TestSupplyVaultBase.t.sol
+++ b/test/aave-v2/TestSupplyVaultBase.t.sol
@@ -15,12 +15,12 @@ contract TestSupplyVaultBase is TestSetupVaults {
         assertEq(daiSupplyVault.recipient(), address(1));
     }
 
-    function testCannotTransferRewardsToNotSetZeroAddress() public {
+    function testCannotTransferRewardsToZeroAddress() public {
         vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
         daiSupplyVault.transferRewards();
     }
 
-    function testEverybodyCanTransferRewardsToRecipient(uint256 _amount) public {
+    function testShouldTransferRewardsToRecipient(uint256 _amount) public {
         vm.assume(_amount > 0);
 
         daiSupplyVault.setRewardsRecipient(address(1));

--- a/test/aave-v2/TestSupplyVaultBase.t.sol
+++ b/test/aave-v2/TestSupplyVaultBase.t.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity ^0.8.0;
+
+import "./setup/TestSetupVaults.sol";
+
+contract TestSupplyVaultBase is TestSetupVaults {
+    function testNotOwnerShouldNotSetRecipient() public {
+        vm.prank(address(1));
+        vm.expectRevert("Ownable: caller is not the owner");
+        daiSupplyVault.setRewardsRecipient(address(1));
+    }
+
+    function testOwnerShouldSetRecipient() public {
+        daiSupplyVault.setRewardsRecipient(address(1));
+        assertEq(daiSupplyVault.recipient(), address(1));
+    }
+
+    function testCannotSetRecipientToZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
+        daiSupplyVault.setRewardsRecipient(address(0));
+    }
+
+    function testCannotTransferRewardsToNotSetZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
+        daiSupplyVault.transferRewards();
+    }
+
+    function testEverybodyCanTransferRewardsToRecipient(uint256 _amount) public {
+        vm.assume(_amount > 0);
+
+        daiSupplyVault.setRewardsRecipient(address(1));
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), 0);
+
+        deal(MORPHO_TOKEN, address(daiSupplyVault), _amount);
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), _amount);
+
+        // Allow the vault to transfer rewards.
+        vm.prank(MORPHO_DAO);
+        IRolesAuthority(MORPHO_TOKEN).setUserRole(address(daiSupplyVault), 0, true);
+
+        vm.startPrank(address(2));
+        daiSupplyVault.transferRewards();
+
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), 0);
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), _amount);
+    }
+}

--- a/test/aave-v2/TestSupplyVaultBase.t.sol
+++ b/test/aave-v2/TestSupplyVaultBase.t.sol
@@ -20,9 +20,26 @@ contract TestSupplyVaultBase is TestSetupVaults {
         daiSupplyVault.transferRewards();
     }
 
-    function testShouldTransferRewardsToRecipient(uint256 _amount) public {
+    function testNotOwnerShouldNotTransferRewardsToRecipient(uint256 _amount) public {
         vm.assume(_amount > 0);
+        _prepareTransfer(_amount);
 
+        vm.startPrank(address(2));
+        vm.expectRevert("Ownable: caller is not the owner");
+        daiSupplyVault.transferRewards();
+    }
+
+    function testOwnerShouldTransferRewardsToRecipient(uint256 _amount) public {
+        vm.assume(_amount > 0);
+        _prepareTransfer(_amount);
+
+        daiSupplyVault.transferRewards();
+
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), 0);
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), _amount);
+    }
+
+    function _prepareTransfer(uint256 _amount) internal {
         daiSupplyVault.setRewardsRecipient(address(1));
         assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), 0);
 
@@ -32,11 +49,5 @@ contract TestSupplyVaultBase is TestSetupVaults {
         // Allow the vault to transfer rewards.
         vm.prank(MORPHO_DAO);
         IRolesAuthority(MORPHO_TOKEN).setUserRole(address(daiSupplyVault), 0, true);
-
-        vm.startPrank(address(2));
-        daiSupplyVault.transferRewards();
-
-        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), 0);
-        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), _amount);
     }
 }

--- a/test/aave-v2/TestSupplyVaultBase.t.sol
+++ b/test/aave-v2/TestSupplyVaultBase.t.sol
@@ -15,11 +15,6 @@ contract TestSupplyVaultBase is TestSetupVaults {
         assertEq(daiSupplyVault.recipient(), address(1));
     }
 
-    function testCannotSetRecipientToZeroAddress() public {
-        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
-        daiSupplyVault.setRewardsRecipient(address(0));
-    }
-
     function testCannotTransferRewardsToNotSetZeroAddress() public {
         vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
         daiSupplyVault.transferRewards();

--- a/test/aave-v2/TestUpgradeable.t.sol
+++ b/test/aave-v2/TestUpgradeable.t.sol
@@ -7,7 +7,7 @@ contract TestUpgradeable is TestSetupVaults {
     using WadRayMath for uint256;
 
     function testUpgradeSupplyVault() public {
-        SupplyVault wNativeSupplyVaultImplV2 = new SupplyVault(address(morpho));
+        SupplyVault wNativeSupplyVaultImplV2 = new SupplyVault(address(morpho), MORPHO_TOKEN);
 
         vm.record();
         proxyAdmin.upgrade(wNativeSupplyVaultProxy, address(wNativeSupplyVaultImplV2));
@@ -25,7 +25,7 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testOnlyProxyOwnerCanUpgradeSupplyVault() public {
-        SupplyVault supplyVaultImplV2 = new SupplyVault(address(morpho));
+        SupplyVault supplyVaultImplV2 = new SupplyVault(address(morpho), MORPHO_TOKEN);
 
         vm.prank(address(supplier1));
         vm.expectRevert("Ownable: caller is not the owner");
@@ -35,7 +35,7 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testOnlyProxyOwnerCanUpgradeAndCallSupplyVault() public {
-        SupplyVault wNativeSupplyVaultImplV2 = new SupplyVault(address(morpho));
+        SupplyVault wNativeSupplyVaultImplV2 = new SupplyVault(address(morpho), MORPHO_TOKEN);
 
         vm.prank(address(supplier1));
         vm.expectRevert("Ownable: caller is not the owner");

--- a/test/aave-v2/helpers/SupplyVaultBaseMock.sol
+++ b/test/aave-v2/helpers/SupplyVaultBaseMock.sol
@@ -4,5 +4,5 @@ pragma solidity 0.8.13;
 import {SupplyVaultBase} from "src/aave-v2/SupplyVaultBase.sol";
 
 contract SupplyVaultBaseMock is SupplyVaultBase {
-    constructor(address _morpho) SupplyVaultBase(_morpho) {}
+    constructor(address _morpho, address _morphoToken) SupplyVaultBase(_morpho, _morphoToken) {}
 }

--- a/test/aave-v2/helpers/SupplyVaultBaseMock.sol
+++ b/test/aave-v2/helpers/SupplyVaultBaseMock.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity 0.8.13;
+
+import {SupplyVaultBase} from "src/aave-v2/SupplyVaultBase.sol";
+
+contract SupplyVaultBaseMock is SupplyVaultBase {
+    constructor(address _morpho) SupplyVaultBase(_morpho) {}
+}

--- a/test/aave-v2/setup/TestSetupVaults.sol
+++ b/test/aave-v2/setup/TestSetupVaults.sol
@@ -6,11 +6,16 @@ import "@tests/aave-v2/setup/TestSetup.sol";
 import {SupplyVaultBase} from "@vaults/aave-v2/SupplyVaultBase.sol";
 import {SupplyVault} from "@vaults/aave-v2/SupplyVault.sol";
 
+import "../../helpers/interfaces/IRolesAuthority.sol";
 import "../../helpers/FakeToken.sol";
 import "../helpers/VaultUser.sol";
+import "../helpers/SupplyVaultBaseMock.sol";
 
 contract TestSetupVaults is TestSetup {
     using SafeTransferLib for ERC20;
+
+    address internal constant MORPHO_DAO = 0xcBa28b38103307Ec8dA98377ffF9816C164f9AFa;
+    address internal constant MORPHO_TOKEN = 0x9994E35Db50125E0DF82e4c2dde62496CE330999;
 
     TransparentUpgradeableProxy internal wNativeSupplyVaultProxy;
 
@@ -19,6 +24,7 @@ contract TestSetupVaults is TestSetup {
     SupplyVault internal wNativeSupplyVault;
     SupplyVault internal daiSupplyVault;
     SupplyVault internal usdcSupplyVault;
+    SupplyVaultBase internal supplyVaultBase;
 
     ERC20 internal ma2WNative;
     ERC20 internal ma2Dai;
@@ -42,6 +48,16 @@ contract TestSetupVaults is TestSetup {
 
     function initVaultContracts() internal {
         supplyVaultImplV1 = new SupplyVault(address(morpho));
+
+        supplyVaultBase = SupplyVaultBase(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(new SupplyVaultBaseMock(address(morpho))),
+                    address(proxyAdmin),
+                    ""
+                )
+            )
+        );
 
         wNativeSupplyVaultProxy = new TransparentUpgradeableProxy(
             address(supplyVaultImplV1),

--- a/test/aave-v2/setup/TestSetupVaults.sol
+++ b/test/aave-v2/setup/TestSetupVaults.sol
@@ -47,12 +47,12 @@ contract TestSetupVaults is TestSetup {
     }
 
     function initVaultContracts() internal {
-        supplyVaultImplV1 = new SupplyVault(address(morpho));
+        supplyVaultImplV1 = new SupplyVault(address(morpho), MORPHO_TOKEN);
 
         supplyVaultBase = SupplyVaultBase(
             address(
                 new TransparentUpgradeableProxy(
-                    address(new SupplyVaultBaseMock(address(morpho))),
+                    address(new SupplyVaultBaseMock(address(morpho), MORPHO_TOKEN)),
                     address(proxyAdmin),
                     ""
                 )

--- a/test/aave-v3/TestSupplyHarvestVault.t.sol
+++ b/test/aave-v3/TestSupplyHarvestVault.t.sol
@@ -45,7 +45,10 @@ contract TestSupplyHarvestVault is TestSetupVaults {
         );
 
         vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
-        new SupplyHarvestVault(address(0), address(0));
+        new SupplyHarvestVault(address(0), address(1));
+
+        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
+        new SupplyHarvestVault(address(1), address(0));
 
         vm.expectRevert();
         vault.initialize(address(0), "test", "test", 0, 0, address(swapper));

--- a/test/aave-v3/TestSupplyHarvestVault.t.sol
+++ b/test/aave-v3/TestSupplyHarvestVault.t.sol
@@ -29,7 +29,10 @@ contract TestSupplyHarvestVault is TestSetupVaults {
     }
 
     function testInitializationShouldRevertWithWrongInputs() public {
-        SupplyHarvestVault supplyHarvestVaultImpl = new SupplyHarvestVault(address(morpho));
+        SupplyHarvestVault supplyHarvestVaultImpl = new SupplyHarvestVault(
+            address(morpho),
+            MORPHO_TOKEN
+        );
 
         SupplyHarvestVault vault = SupplyHarvestVault(
             address(
@@ -42,7 +45,7 @@ contract TestSupplyHarvestVault is TestSetupVaults {
         );
 
         vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
-        new SupplyHarvestVault(address(0));
+        new SupplyHarvestVault(address(0), address(0));
 
         vm.expectRevert();
         vault.initialize(address(0), "test", "test", 0, 0, address(swapper));
@@ -333,28 +336,6 @@ contract TestSupplyHarvestVault is TestSetupVaults {
 
         daiSupplyHarvestVault.setSwapper(address(1));
         assertEq(address(daiSupplyHarvestVault.swapper()), address(1));
-    }
-
-    function testNotOwnerShouldNotTransferTokens(uint256 _amount) public {
-        vm.prank(address(1));
-        vm.expectRevert("Ownable: caller is not the owner");
-        daiSupplyVault.transferTokens($token, address(2), _amount);
-    }
-
-    function testOwnerShouldTransferTokens(
-        address _to,
-        uint256 _deal,
-        uint256 _toTransfer
-    ) public {
-        vm.assume(_to != address(daiSupplyHarvestVault));
-        _toTransfer = bound(_toTransfer, 0, _deal);
-        deal($token, address(daiSupplyHarvestVault), _deal);
-
-        vm.prank(daiSupplyHarvestVault.owner());
-        daiSupplyHarvestVault.transferTokens($token, _to, _toTransfer);
-
-        assertEq(token.balanceOf(address(daiSupplyHarvestVault)), _deal - _toTransfer);
-        assertEq(token.balanceOf(_to), _toTransfer);
     }
 
     /// SETTERS ///

--- a/test/aave-v3/TestSupplyVault.t.sol
+++ b/test/aave-v3/TestSupplyVault.t.sol
@@ -467,26 +467,4 @@ contract TestSupplyVault is TestSetupVaults {
             "unexpected rewards amount 2-3"
         ); // not exact because of rewardTokenounded interests
     }
-
-    function testNotOwnerShouldNotTransferTokens(uint256 _amount) public {
-        vm.prank(address(1));
-        vm.expectRevert("Ownable: caller is not the owner");
-        daiSupplyVault.transferTokens($token, address(2), _amount);
-    }
-
-    function testOwnerShouldTransferTokens(
-        address _to,
-        uint256 _deal,
-        uint256 _toTransfer
-    ) public {
-        vm.assume(_to != address(daiSupplyVault));
-        _toTransfer = bound(_toTransfer, 0, _deal);
-        deal($token, address(daiSupplyVault), _deal);
-
-        vm.prank(daiSupplyVault.owner());
-        daiSupplyVault.transferTokens($token, _to, _toTransfer);
-
-        assertEq(token.balanceOf(address(daiSupplyVault)), _deal - _toTransfer);
-        assertEq(token.balanceOf(_to), _toTransfer);
-    }
 }

--- a/test/aave-v3/TestSupplyVaultBase.t.sol
+++ b/test/aave-v3/TestSupplyVaultBase.t.sol
@@ -15,12 +15,12 @@ contract TestSupplyVaultBase is TestSetupVaults {
         assertEq(daiSupplyVault.recipient(), address(1));
     }
 
-    function testCannotTransferRewardsToNotSetZeroAddress() public {
+    function testCannotTransferRewardsToZeroAddress() public {
         vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
         daiSupplyVault.transferRewards();
     }
 
-    function testEverybodyCanTransferRewardsToRecipient(uint256 _amount) public {
+    function testShouldTransferRewardsToRecipient(uint256 _amount) public {
         vm.assume(_amount > 0);
 
         daiSupplyVault.setRewardsRecipient(address(1));

--- a/test/aave-v3/TestSupplyVaultBase.t.sol
+++ b/test/aave-v3/TestSupplyVaultBase.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity ^0.8.0;
+
+import "./setup/TestSetupVaults.sol";
+
+contract TestSupplyVaultBase is TestSetupVaults {
+    function testNotOwnerShouldNotSetRecipient() public {
+        vm.prank(address(1));
+        vm.expectRevert("Ownable: caller is not the owner");
+        daiSupplyVault.setRewardsRecipient(address(1));
+    }
+
+    function testOwnerShouldSetRecipient() public {
+        daiSupplyVault.setRewardsRecipient(address(1));
+        assertEq(daiSupplyVault.recipient(), address(1));
+    }
+
+    function testCannotSetRecipientToZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
+        daiSupplyVault.setRewardsRecipient(address(0));
+    }
+
+    function testCannotTransferRewardsToNotSetZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
+        daiSupplyVault.transferRewards();
+    }
+
+    function testEverybodyCanTransferRewardsToRecipient(uint256 _amount) public {
+        vm.assume(_amount > 0);
+
+        daiSupplyVault.setRewardsRecipient(address(1));
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), 0);
+
+        deal(MORPHO_TOKEN, address(daiSupplyVault), _amount);
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), _amount);
+
+        vm.startPrank(address(2));
+        daiSupplyVault.transferRewards();
+
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), 0);
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), _amount);
+    }
+}

--- a/test/aave-v3/TestSupplyVaultBase.t.sol
+++ b/test/aave-v3/TestSupplyVaultBase.t.sol
@@ -45,9 +45,5 @@ contract TestSupplyVaultBase is TestSetupVaults {
 
         deal(MORPHO_TOKEN, address(daiSupplyVault), _amount);
         assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), _amount);
-
-        // Allow the vault to transfer rewards.
-        vm.prank(MORPHO_DAO);
-        IRolesAuthority(MORPHO_TOKEN).setUserRole(address(daiSupplyVault), 0, true);
     }
 }

--- a/test/aave-v3/TestSupplyVaultBase.t.sol
+++ b/test/aave-v3/TestSupplyVaultBase.t.sol
@@ -15,11 +15,6 @@ contract TestSupplyVaultBase is TestSetupVaults {
         assertEq(daiSupplyVault.recipient(), address(1));
     }
 
-    function testCannotSetRecipientToZeroAddress() public {
-        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
-        daiSupplyVault.setRewardsRecipient(address(0));
-    }
-
     function testCannotTransferRewardsToNotSetZeroAddress() public {
         vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
         daiSupplyVault.transferRewards();

--- a/test/aave-v3/TestUpgradeable.t.sol
+++ b/test/aave-v3/TestUpgradeable.t.sol
@@ -7,7 +7,10 @@ contract TestUpgradeable is TestSetupVaults {
     using WadRayMath for uint256;
 
     function testUpgradeSupplyHarvestVault() public {
-        SupplyHarvestVault wethSupplyHarvestVaultImplV2 = new SupplyHarvestVault(address(morpho));
+        SupplyHarvestVault wethSupplyHarvestVaultImplV2 = new SupplyHarvestVault(
+            address(morpho),
+            MORPHO_TOKEN
+        );
 
         vm.record();
         proxyAdmin.upgrade(
@@ -28,7 +31,10 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testOnlyProxyOwnerCanUpgradeSupplyHarvestVault() public {
-        SupplyHarvestVault supplyHarvestVaultImplV2 = new SupplyHarvestVault(address(morpho));
+        SupplyHarvestVault supplyHarvestVaultImplV2 = new SupplyHarvestVault(
+            address(morpho),
+            MORPHO_TOKEN
+        );
 
         vm.prank(address(supplier1));
         vm.expectRevert("Ownable: caller is not the owner");
@@ -44,7 +50,10 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testOnlyProxyOwnerCanUpgradeAndCallSupplyHarvestVault() public {
-        SupplyHarvestVault wethSupplyHarvestVaultImplV2 = new SupplyHarvestVault(address(morpho));
+        SupplyHarvestVault wethSupplyHarvestVaultImplV2 = new SupplyHarvestVault(
+            address(morpho),
+            MORPHO_TOKEN
+        );
 
         vm.prank(address(supplier1));
         vm.expectRevert("Ownable: caller is not the owner");
@@ -76,7 +85,7 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testUpgradeSupplyVault() public {
-        SupplyVault wethSupplyVaultImplV2 = new SupplyVault(address(morpho));
+        SupplyVault wethSupplyVaultImplV2 = new SupplyVault(address(morpho), MORPHO_TOKEN);
 
         vm.record();
         proxyAdmin.upgrade(wrappedNativeTokenSupplyVaultProxy, address(wethSupplyVaultImplV2));
@@ -94,7 +103,7 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testOnlyProxyOwnerCanUpgradeSupplyVault() public {
-        SupplyVault supplyVaultImplV2 = new SupplyVault(address(morpho));
+        SupplyVault supplyVaultImplV2 = new SupplyVault(address(morpho), MORPHO_TOKEN);
 
         vm.prank(address(supplier1));
         vm.expectRevert("Ownable: caller is not the owner");
@@ -104,7 +113,7 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testOnlyProxyOwnerCanUpgradeAndCallSupplyVault() public {
-        SupplyVault wethSupplyVaultImplV2 = new SupplyVault(address(morpho));
+        SupplyVault wethSupplyVaultImplV2 = new SupplyVault(address(morpho), MORPHO_TOKEN);
 
         vm.prank(address(supplier1));
         vm.expectRevert("Ownable: caller is not the owner");

--- a/test/aave-v3/helpers/SupplyVaultBaseMock.sol
+++ b/test/aave-v3/helpers/SupplyVaultBaseMock.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity >=0.8.0;
+
+import {SupplyVaultBase} from "src/aave-v3/SupplyVaultBase.sol";
+
+contract SupplyVaultBaseMock is SupplyVaultBase {
+    constructor(address _morpho, address _morphoToken) SupplyVaultBase(_morpho, _morphoToken) {}
+}

--- a/test/aave-v3/setup/TestSetupVaults.sol
+++ b/test/aave-v3/setup/TestSetupVaults.sol
@@ -12,9 +12,12 @@ import {UniswapV3Swapper} from "@vaults/UniswapV3Swapper.sol";
 
 import "../../helpers/FakeToken.sol";
 import "../helpers/VaultUser.sol";
+import "../helpers/SupplyVaultBaseMock.sol";
 
 contract TestSetupVaults is TestSetup {
     using SafeTransferLib for ERC20;
+
+    address internal MORPHO_TOKEN = address(new FakeToken("Morpho Token", "MORPHO"));
 
     TransparentUpgradeableProxy internal wrappedNativeTokenSupplyVaultProxy;
     TransparentUpgradeableProxy internal wrappedNativeTokenSupplyHarvestVaultProxy;
@@ -28,6 +31,7 @@ contract TestSetupVaults is TestSetup {
     SupplyHarvestVault internal wrappedNativeTokenSupplyHarvestVault;
     SupplyHarvestVault internal daiSupplyHarvestVault;
     SupplyHarvestVault internal usdcSupplyHarvestVault;
+    SupplyVaultBase internal supplyVaultBase;
 
     ISwapper internal swapper;
 
@@ -64,8 +68,18 @@ contract TestSetupVaults is TestSetup {
 
         createMarket(aWrappedNativeToken);
 
-        supplyVaultImplV1 = new SupplyVault(address(morpho));
-        supplyHarvestVaultImplV1 = new SupplyHarvestVault(address(morpho));
+        supplyVaultImplV1 = new SupplyVault(address(morpho), MORPHO_TOKEN);
+        supplyHarvestVaultImplV1 = new SupplyHarvestVault(address(morpho), MORPHO_TOKEN);
+
+        supplyVaultBase = SupplyVaultBase(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(new SupplyVaultBaseMock(address(morpho), MORPHO_TOKEN)),
+                    address(proxyAdmin),
+                    ""
+                )
+            )
+        );
 
         wrappedNativeTokenSupplyHarvestVaultProxy = new TransparentUpgradeableProxy(
             address(supplyHarvestVaultImplV1),

--- a/test/compound/TestEth.t.sol
+++ b/test/compound/TestEth.t.sol
@@ -40,7 +40,7 @@ contract TestEth is TestSetupVaults {
         );
     }
 
-    function testShouldWithdrawethOnVault() public {
+    function testShouldWithdraWethOnVault() public {
         uint256 amount = 1 ether;
 
         uint256 poolSupplyIndex = ICToken(cEth).exchangeRateCurrent();

--- a/test/compound/TestSupplyHarvestVault.t.sol
+++ b/test/compound/TestSupplyHarvestVault.t.sol
@@ -33,7 +33,10 @@ contract TestSupplyHarvestVault is TestSetupVaults {
     }
 
     function testInitializationShouldRevertWithWrongInputs() public {
-        SupplyHarvestVault supplyHarvestVaultImpl = new SupplyHarvestVault(address(morpho));
+        SupplyHarvestVault supplyHarvestVaultImpl = new SupplyHarvestVault(
+            address(morpho),
+            MORPHO_TOKEN
+        );
 
         SupplyHarvestVault vault = SupplyHarvestVault(
             address(
@@ -46,7 +49,7 @@ contract TestSupplyHarvestVault is TestSetupVaults {
         );
 
         vm.expectRevert();
-        new SupplyHarvestVault(address(0));
+        new SupplyHarvestVault(address(0), MORPHO_TOKEN);
 
         // TODO: Fix this test. Test is failing with:
         // FAIL. Reason: Error != expected error: Contract 0x0000000000000000000000000000000000000000 does not exist and is not marked as persistent, see `vm.makePersistent()` != 0xd92e233d

--- a/test/compound/TestSupplyHarvestVault.t.sol
+++ b/test/compound/TestSupplyHarvestVault.t.sol
@@ -352,28 +352,6 @@ contract TestSupplyHarvestVault is TestSetupVaults {
         assertEq(daiSupplyHarvestVault.harvestingFee(), 1);
     }
 
-    function testNotOwnerShouldNotTransferTokens(uint256 _amount) public {
-        vm.prank(address(1));
-        vm.expectRevert("Ownable: caller is not the owner");
-        daiSupplyHarvestVault.transferTokens($token, address(2), _amount);
-    }
-
-    function testOwnerShouldTransferTokens(
-        address _to,
-        uint256 _deal,
-        uint256 _toTransfer
-    ) public {
-        vm.assume(_to != address(daiSupplyHarvestVault));
-        _toTransfer = bound(_toTransfer, 0, _deal);
-        deal($token, address(daiSupplyHarvestVault), _deal);
-
-        vm.prank(daiSupplyHarvestVault.owner());
-        daiSupplyHarvestVault.transferTokens($token, _to, _toTransfer);
-
-        assertEq(token.balanceOf(address(daiSupplyHarvestVault)), _deal - _toTransfer);
-        assertEq(token.balanceOf(_to), _toTransfer);
-    }
-
     /// SETTERS ///
 
     function testShouldNotSetCompSwapFeeTooLarge() public {

--- a/test/compound/TestSupplyVault.t.sol
+++ b/test/compound/TestSupplyVault.t.sol
@@ -333,47 +333,6 @@ contract TestSupplyVault is TestSetupVaults {
         assertApproxEqAbs(rewardsAmount2, rewardsAmount3, 1e9, "unexpected rewards amount 2-3"); // not exact because of compounded interests
     }
 
-    function testNotOwnerShouldNotSetRecipient() public {
-        vm.prank(address(1));
-        vm.expectRevert("Ownable: caller is not the owner");
-        daiSupplyVault.setRewardsRecipient(address(1));
-    }
-
-    function testOwnerShouldSetRecipient() public {
-        daiSupplyVault.setRewardsRecipient(address(1));
-        assertEq(daiSupplyVault.recipient(), address(1));
-    }
-
-    function testCannotSetRecipientToZeroAddress() public {
-        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
-        daiSupplyVault.setRewardsRecipient(address(0));
-    }
-
-    function testCannotTransferRewardsToNotSetZeroAddress() public {
-        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
-        daiSupplyVault.transferRewards();
-    }
-
-    function testEverybodyCanTransferRewardsToRecipient(uint256 _amount) public {
-        vm.assume(_amount > 0);
-
-        daiSupplyVault.setRewardsRecipient(address(1));
-        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), 0);
-
-        deal(MORPHO_TOKEN, address(daiSupplyVault), _amount);
-        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), _amount);
-
-        // Allow the vault to transfer rewards.
-        vm.prank(MORPHO_DAO);
-        IRolesAuthority(MORPHO_TOKEN).setUserRole(address(daiSupplyVault), 0, true);
-
-        vm.startPrank(address(2));
-        daiSupplyVault.transferRewards();
-
-        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), 0);
-        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), _amount);
-    }
-
     function testAccrueRewardsToCorrectUser() public {
         uint256 amount = 1e6 ether;
 

--- a/test/compound/TestSupplyVault.t.sol
+++ b/test/compound/TestSupplyVault.t.sol
@@ -336,17 +336,17 @@ contract TestSupplyVault is TestSetupVaults {
     function testNotOwnerShouldNotSetRecipient() public {
         vm.prank(address(1));
         vm.expectRevert("Ownable: caller is not the owner");
-        daiSupplyVault.setRecipient(address(1));
+        daiSupplyVault.setRewardsRecipient(address(1));
     }
 
     function testOwnerShouldSetRecipient() public {
-        daiSupplyVault.setRecipient(address(1));
+        daiSupplyVault.setRewardsRecipient(address(1));
         assertEq(daiSupplyVault.recipient(), address(1));
     }
 
     function testCannotSetRecipientToZeroAddress() public {
         vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
-        daiSupplyVault.setRecipient(address(0));
+        daiSupplyVault.setRewardsRecipient(address(0));
     }
 
     function testCannotTransferRewardsToNotSetZeroAddress() public {
@@ -357,7 +357,7 @@ contract TestSupplyVault is TestSetupVaults {
     function testEverybodyCanTransferRewardsToRecipient(uint256 _amount) public {
         vm.assume(_amount > 0);
 
-        daiSupplyVault.setRecipient(address(1));
+        daiSupplyVault.setRewardsRecipient(address(1));
         assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), 0);
 
         deal(MORPHO_TOKEN, address(daiSupplyVault), _amount);

--- a/test/compound/TestSupplyVaultBase.t.sol
+++ b/test/compound/TestSupplyVaultBase.t.sol
@@ -15,12 +15,12 @@ contract TestSupplyVaultBase is TestSetupVaults {
         assertEq(daiSupplyVault.recipient(), address(1));
     }
 
-    function testCannotTransferRewardsToNotSetZeroAddress() public {
+    function testCannotTransferRewardsToZeroAddress() public {
         vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
         daiSupplyVault.transferRewards();
     }
 
-    function testEverybodyCanTransferRewardsToRecipient(uint256 _amount) public {
+    function testShouldTransferRewardsToRecipient(uint256 _amount) public {
         vm.assume(_amount > 0);
 
         daiSupplyVault.setRewardsRecipient(address(1));

--- a/test/compound/TestSupplyVaultBase.t.sol
+++ b/test/compound/TestSupplyVaultBase.t.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity ^0.8.0;
+
+import "./setup/TestSetupVaults.sol";
+
+contract TestSupplyVaultBase is TestSetupVaults {
+    function testNotOwnerShouldNotSetRecipient() public {
+        vm.prank(address(1));
+        vm.expectRevert("Ownable: caller is not the owner");
+        daiSupplyVault.setRewardsRecipient(address(1));
+    }
+
+    function testOwnerShouldSetRecipient() public {
+        daiSupplyVault.setRewardsRecipient(address(1));
+        assertEq(daiSupplyVault.recipient(), address(1));
+    }
+
+    function testCannotSetRecipientToZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
+        daiSupplyVault.setRewardsRecipient(address(0));
+    }
+
+    function testCannotTransferRewardsToNotSetZeroAddress() public {
+        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
+        daiSupplyVault.transferRewards();
+    }
+
+    function testEverybodyCanTransferRewardsToRecipient(uint256 _amount) public {
+        vm.assume(_amount > 0);
+
+        daiSupplyVault.setRewardsRecipient(address(1));
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), 0);
+
+        deal(MORPHO_TOKEN, address(daiSupplyVault), _amount);
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), _amount);
+
+        // Allow the vault to transfer rewards.
+        vm.prank(MORPHO_DAO);
+        IRolesAuthority(MORPHO_TOKEN).setUserRole(address(daiSupplyVault), 0, true);
+
+        vm.startPrank(address(2));
+        daiSupplyVault.transferRewards();
+
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), 0);
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), _amount);
+    }
+}

--- a/test/compound/TestSupplyVaultBase.t.sol
+++ b/test/compound/TestSupplyVaultBase.t.sol
@@ -20,9 +20,26 @@ contract TestSupplyVaultBase is TestSetupVaults {
         daiSupplyVault.transferRewards();
     }
 
-    function testShouldTransferRewardsToRecipient(uint256 _amount) public {
+    function testNotOwnerShouldNotTransferRewardsToRecipient(uint256 _amount) public {
         vm.assume(_amount > 0);
+        _prepareTransfer(_amount);
 
+        vm.startPrank(address(2));
+        vm.expectRevert("Ownable: caller is not the owner");
+        daiSupplyVault.transferRewards();
+    }
+
+    function testOwnerShouldTransferRewardsToRecipient(uint256 _amount) public {
+        vm.assume(_amount > 0);
+        _prepareTransfer(_amount);
+
+        daiSupplyVault.transferRewards();
+
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), 0);
+        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), _amount);
+    }
+
+    function _prepareTransfer(uint256 _amount) internal {
         daiSupplyVault.setRewardsRecipient(address(1));
         assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), 0);
 
@@ -32,11 +49,5 @@ contract TestSupplyVaultBase is TestSetupVaults {
         // Allow the vault to transfer rewards.
         vm.prank(MORPHO_DAO);
         IRolesAuthority(MORPHO_TOKEN).setUserRole(address(daiSupplyVault), 0, true);
-
-        vm.startPrank(address(2));
-        daiSupplyVault.transferRewards();
-
-        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(daiSupplyVault)), 0);
-        assertEq(ERC20(MORPHO_TOKEN).balanceOf(address(1)), _amount);
     }
 }

--- a/test/compound/TestSupplyVaultBase.t.sol
+++ b/test/compound/TestSupplyVaultBase.t.sol
@@ -15,11 +15,6 @@ contract TestSupplyVaultBase is TestSetupVaults {
         assertEq(daiSupplyVault.recipient(), address(1));
     }
 
-    function testCannotSetRecipientToZeroAddress() public {
-        vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
-        daiSupplyVault.setRewardsRecipient(address(0));
-    }
-
     function testCannotTransferRewardsToNotSetZeroAddress() public {
         vm.expectRevert(abi.encodeWithSelector(SupplyVaultBase.ZeroAddress.selector));
         daiSupplyVault.transferRewards();

--- a/test/compound/TestUpgradeable.t.sol
+++ b/test/compound/TestUpgradeable.t.sol
@@ -7,7 +7,10 @@ contract TestUpgradeable is TestSetupVaults {
     using CompoundMath for uint256;
 
     function testUpgradeSupplyHarvestVault() public {
-        SupplyHarvestVault wethSupplyHarvestVaultImplV2 = new SupplyHarvestVault(address(morpho));
+        SupplyHarvestVault wethSupplyHarvestVaultImplV2 = new SupplyHarvestVault(
+            address(morpho),
+            MORPHO_TOKEN
+        );
 
         vm.record();
         proxyAdmin.upgrade(wethSupplyHarvestVaultProxy, address(wethSupplyHarvestVaultImplV2));
@@ -25,7 +28,10 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testOnlyProxyOwnerCanUpgradeSupplyHarvestVault() public {
-        SupplyHarvestVault supplyHarvestVaultImplV2 = new SupplyHarvestVault(address(morpho));
+        SupplyHarvestVault supplyHarvestVaultImplV2 = new SupplyHarvestVault(
+            address(morpho),
+            MORPHO_TOKEN
+        );
 
         vm.prank(address(supplier1));
         vm.expectRevert("Ownable: caller is not the owner");
@@ -35,7 +41,10 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testOnlyProxyOwnerCanUpgradeAndCallSupplyHarvestVault() public {
-        SupplyHarvestVault wethSupplyHarvestVaultImplV2 = new SupplyHarvestVault(address(morpho));
+        SupplyHarvestVault wethSupplyHarvestVaultImplV2 = new SupplyHarvestVault(
+            address(morpho),
+            MORPHO_TOKEN
+        );
 
         vm.prank(address(supplier1));
         vm.expectRevert("Ownable: caller is not the owner");
@@ -66,7 +75,7 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testUpgradeSupplyVault() public {
-        SupplyVault wethSupplyVaultImplV2 = new SupplyVault(address(morpho));
+        SupplyVault wethSupplyVaultImplV2 = new SupplyVault(address(morpho), MORPHO_TOKEN);
 
         vm.record();
         proxyAdmin.upgrade(wethSupplyVaultProxy, address(wethSupplyVaultImplV2));
@@ -84,7 +93,7 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testOnlyProxyOwnerCanUpgradeSupplyVault() public {
-        SupplyVault supplyVaultImplV2 = new SupplyVault(address(morpho));
+        SupplyVault supplyVaultImplV2 = new SupplyVault(address(morpho), MORPHO_TOKEN);
 
         vm.prank(address(supplier1));
         vm.expectRevert("Ownable: caller is not the owner");
@@ -94,7 +103,7 @@ contract TestUpgradeable is TestSetupVaults {
     }
 
     function testOnlyProxyOwnerCanUpgradeAndCallSupplyVault() public {
-        SupplyVault wethSupplyVaultImplV2 = new SupplyVault(address(morpho));
+        SupplyVault wethSupplyVaultImplV2 = new SupplyVault(address(morpho), MORPHO_TOKEN);
 
         vm.prank(address(supplier1));
         vm.expectRevert("Ownable: caller is not the owner");

--- a/test/compound/helpers/SupplyVaultBaseMock.sol
+++ b/test/compound/helpers/SupplyVaultBaseMock.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity 0.8.13;
+
+import {SupplyVaultBase} from "src/compound/SupplyVaultBase.sol";
+
+contract SupplyVaultBaseMock is SupplyVaultBase {
+    constructor(address _morpho) SupplyVaultBase(_morpho) {}
+}

--- a/test/compound/helpers/SupplyVaultBaseMock.sol
+++ b/test/compound/helpers/SupplyVaultBaseMock.sol
@@ -4,5 +4,5 @@ pragma solidity 0.8.13;
 import {SupplyVaultBase} from "src/compound/SupplyVaultBase.sol";
 
 contract SupplyVaultBaseMock is SupplyVaultBase {
-    constructor(address _morpho) SupplyVaultBase(_morpho) {}
+    constructor(address _morpho, address _morphoToken) SupplyVaultBase(_morpho, _morphoToken) {}
 }

--- a/test/compound/setup/TestSetupVaults.sol
+++ b/test/compound/setup/TestSetupVaults.sol
@@ -12,6 +12,7 @@ import "@morpho-labs/morpho-utils/math/PercentageMath.sol";
 import "../../helpers/interfaces/IRolesAuthority.sol";
 import "../../helpers/FakeToken.sol";
 import "../helpers/VaultUser.sol";
+import "../helpers/SupplyVaultBaseMock.sol";
 
 contract TestSetupVaults is TestSetup {
     using SafeTransferLib for ERC20;
@@ -32,6 +33,7 @@ contract TestSetupVaults is TestSetup {
     SupplyHarvestVault internal daiSupplyHarvestVault;
     SupplyHarvestVault internal usdcSupplyHarvestVault;
     SupplyHarvestVault internal compSupplyHarvestVault;
+    SupplyVaultBase internal supplyVaultBase;
 
     ERC20 internal mcWeth;
     ERC20 internal mcDai;
@@ -61,6 +63,16 @@ contract TestSetupVaults is TestSetup {
     function initVaultContracts() internal {
         supplyVaultImplV1 = new SupplyVault(address(morpho));
         supplyHarvestVaultImplV1 = new SupplyHarvestVault(address(morpho));
+
+        supplyVaultBase = SupplyVaultBase(
+            address(
+                new TransparentUpgradeableProxy(
+                    address(new SupplyVaultBaseMock(address(morpho))),
+                    address(proxyAdmin),
+                    ""
+                )
+            )
+        );
 
         wethSupplyHarvestVaultProxy = new TransparentUpgradeableProxy(
             address(supplyHarvestVaultImplV1),

--- a/test/compound/setup/TestSetupVaults.sol
+++ b/test/compound/setup/TestSetupVaults.sol
@@ -61,13 +61,13 @@ contract TestSetupVaults is TestSetup {
     }
 
     function initVaultContracts() internal {
-        supplyVaultImplV1 = new SupplyVault(address(morpho));
-        supplyHarvestVaultImplV1 = new SupplyHarvestVault(address(morpho));
+        supplyVaultImplV1 = new SupplyVault(address(morpho), MORPHO_TOKEN);
+        supplyHarvestVaultImplV1 = new SupplyHarvestVault(address(morpho), MORPHO_TOKEN);
 
         supplyVaultBase = SupplyVaultBase(
             address(
                 new TransparentUpgradeableProxy(
-                    address(new SupplyVaultBaseMock(address(morpho))),
+                    address(new SupplyVaultBaseMock(address(morpho), MORPHO_TOKEN)),
                     address(proxyAdmin),
                     ""
                 )

--- a/test/compound/setup/TestSetupVaults.sol
+++ b/test/compound/setup/TestSetupVaults.sol
@@ -9,11 +9,15 @@ import {SupplyVault} from "@vaults/compound/SupplyVault.sol";
 
 import "@morpho-labs/morpho-utils/math/PercentageMath.sol";
 
+import "../../helpers/interfaces/IRolesAuthority.sol";
 import "../../helpers/FakeToken.sol";
 import "../helpers/VaultUser.sol";
 
 contract TestSetupVaults is TestSetup {
     using SafeTransferLib for ERC20;
+
+    address internal constant MORPHO_DAO = 0xcBa28b38103307Ec8dA98377ffF9816C164f9AFa;
+    address internal constant MORPHO_TOKEN = 0x9994E35Db50125E0DF82e4c2dde62496CE330999;
 
     TransparentUpgradeableProxy internal wethSupplyVaultProxy;
     TransparentUpgradeableProxy internal wethSupplyHarvestVaultProxy;

--- a/test/helpers/interfaces/IRolesAuthority.sol
+++ b/test/helpers/interfaces/IRolesAuthority.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GNU AGPLv3
+pragma solidity >=0.5.0;
+
+interface IRolesAuthority {
+    function setUserRole(
+        address user,
+        uint8 role,
+        bool enabled
+    ) external;
+}


### PR DESCRIPTION
# Pull Request

Proposal for the scoping function. With this solution, the DAO just needs to specify the recipient of the rewards once (likely the RewardsDistributor freshly deployed) and after any EOA can transfer rewards offloading the DAO to conduct a vote and a tx to verify each month.

## Issue(s) fixed

This pull request fixes #175 