### PR TITLE
Fix foundry-storage-check interface bug

### DIFF
--- a/.github/workflows/ci-storage-check-aave-v2.yml
+++ b/.github/workflows/ci-storage-check-aave-v2.yml
@@ -36,6 +36,6 @@ jobs:
           version: nightly
 
       - name: Check SupplyVault storage layout
-        uses: Rubilmax/foundry-storage-check@v2
+        uses: Rubilmax/foundry-storage-check@v2.1
         with:
           contract: src/aave-v2/SupplyVault.sol:SupplyVault

--- a/.github/workflows/ci-storage-check-compound.yml
+++ b/.github/workflows/ci-storage-check-compound.yml
@@ -36,11 +36,11 @@ jobs:
           version: nightly
 
       - name: Check SupplyVault storage layout
-        uses: Rubilmax/foundry-storage-check@v2
+        uses: Rubilmax/foundry-storage-check@v2.1
         with:
           contract: src/compound/SupplyVault.sol:SupplyVault
 
       - name: Check SupplyHarvestVault storage layout
-        uses: Rubilmax/foundry-storage-check@v2
+        uses: Rubilmax/foundry-storage-check@v2.1
         with:
           contract: src/compound/SupplyHarvestVault.sol:SupplyHarvestVault


### PR DESCRIPTION
# Pull Request

CI is failing on `upgrade-O`: https://github.com/morpho-dao/morpho-tokenized-vaults/actions/runs/3378148898

Because of a bug discovered 2 weeks ago, which was fixed in version `2.1` of `foundry-storage-check`, but the version was not updated on this repository